### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,35 @@
 
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=id">Bahasa Indonesia</a>
+      </div>
+    </div>
+  </details>
+</div>
+
+
 # Ethereum Staking Guides #
 
 ## Introduction ##


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links : 
- [English](https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=en)
- [简体中文](https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=SomerEsat&project=ethereum-staking-guides&lang=ko)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962" />

If this was not your expection, please close this PR. Thank you! 🙌
